### PR TITLE
Fjerner ubrukt variabel

### DIFF
--- a/examples/autoscaling/main.tf
+++ b/examples/autoscaling/main.tf
@@ -3,14 +3,12 @@ provider "aws" {
 }
 
 locals {
-  name_prefix      = "example"
   application_name = "autoscaling"
 }
 
 module "dynamodb" {
   source = "../../"
 
-  name_prefix      = local.name_prefix
   application_name = local.application_name
   table_name       = "table"
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -3,14 +3,12 @@ provider "aws" {
 }
 
 locals {
-  name_prefix      = "example"
   application_name = "simple"
 }
 
 module "dynamodb" {
   source = "../../"
 
-  name_prefix      = local.name_prefix
   application_name = local.application_name
   table_name       = "table"
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,3 @@
-variable "name_prefix" {
-  description = "A prefix used for naming resources."
-  type        = string
-}
-
 variable "application_name" {
   description = "Name of the application that is using this table"
   type        = string


### PR DESCRIPTION
Siden variabelen `name_prefix` ikke er i bruk kan den like gjerne fjernes. 